### PR TITLE
chore(action): properly forward settings from workflow to env

### DIFF
--- a/.github/workflows/commit-message-validator.yml
+++ b/.github/workflows/commit-message-validator.yml
@@ -15,6 +15,6 @@ jobs:
     - name: Commit message validation
       uses: lumapps/commit-message-validator@master
       with:
-        no_jira: 1
+        no_jira: true
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/action.yml
+++ b/action.yml
@@ -25,6 +25,6 @@ runs:
     - name: Validation
       run: ${{ github.action_path }}/check.sh ${{ github.event.pull_request.base.sha }}..${{ github.event.pull_request.head.sha }}
       env:
-        no_jira: ${{ inputs.no_jira }}
-        allow_temp: ${{ inputs.allow_temp }}
+        COMMIT_VALIDATOR_NO_JIRA: ${{ inputs.no_jira }}
+        COMMIT_VALIDATOR_ALLOW_TEMP: ${{ inputs.allow_temp }}
       shell: bash


### PR DESCRIPTION
Enviroment variables are COMMIT_VALIDATOR_ prefixed.
This cannot be a fix, because we are using master for the action.